### PR TITLE
Fold on "Scenario Outline" keyword

### DIFF
--- a/after/ftplugin/cucumber/folding.vim
+++ b/after/ftplugin/cucumber/folding.vim
@@ -1,7 +1,7 @@
 function! CucumberFolds()
   let thisline = getline(v:lnum)
 
-  if match(thisline, '\(Scenario\|Background\)\:') >= 0
+  if match(thisline, '\(Scenario\( Outline\)\?\|Background\)\:') >= 0
     return ">1"
   else
     return "="

--- a/t/fixtures/sample.feature
+++ b/t/fixtures/sample.feature
@@ -11,3 +11,13 @@ Feature: Testing folding
   Scenario: Second Feature
     When I Foo a second time
     Then I Baz
+
+  Scenario Outline: eating cucumbers
+    Given there are <start> cucumbers
+    When I eat <eat> cucumbers
+    Then I should have <left> cucumbers
+
+    Examples:
+      | start | eat | left |
+      |    12 |   5 |    7 |
+      |    20 |   5 |   15 |

--- a/t/folding.vim
+++ b/t/folding.vim
@@ -22,4 +22,9 @@ describe 'cucumber folds'
     Expect FoldBoundariesInRange(7, 9) toBeClosed
     Expect FoldBoundariesInRange(11, 13) toBeClosed
   end
+
+  it 'folds on `Scenario Outline`'
+    normal zM
+    Expect FoldBoundariesInRange(15, 23) toBeClosed
+  end
 end


### PR DESCRIPTION
Allow folding to happen on the [`Scenario Outline` keyword](https://cucumber.io/docs/gherkin/reference/#scenario-outline)